### PR TITLE
chore(lint): add dom and ESNext compilerOptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "deno.config": "./deno.json",
   "deno.enable": true,
   "deno.lint": true,
   "deno.unstable": true

--- a/deno.json
+++ b/deno.json
@@ -5,5 +5,8 @@
     "cache": "deno cache --reload server.ts",
     "vendor": "importMap=importMap.json deno run -A --unstable https://deno.land/x/ultra@v1.0.1/vendor.ts"
   },
-  "importMap": "importMap.json"
+  "importMap": "importMap.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "dom"]
+  }
 }


### PR DESCRIPTION
This change will provide proper typings for DOM things and the latest ES goodness.

DOM Example:
```
// the linter will no longer complain about this
const inputValue = (event.target as HTMLInputElement).value;
```